### PR TITLE
Update pull request template format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,25 @@
+<!--
+Document all changes and rationale for changes being submitted in the pull
+request in a concise but thorough manner.
+
+Follow the section format defined in this template; if any headings are not
+applicable, please remove them.
+-->
+
 ## Major Changes and Improvements
-  * Describe any major changes to the code and how to use them
+- Describe any major changes to the code and how to use them
 
 ## Bug Fixes
-  * Describe any bugs that the pull request fixes
+- Describe any bugs that the pull request fixes
 
 ## Minor Updates
-  * Describe other minor changes to the code (e.g., README updates)
+- Describe other minor changes to the code (e.g., minor README updates)
 
 ## Tests and Validation
-  * Describe steps taken to ensure functionality and consistency of results with previous code versions
+- Describe steps taken to ensure functionality and consistency of results with previous code versions
 
 ## Issues Closed
-  * Closes ## -- reason why issue is resolved
+- Closes ## -- reason why issue is resolved
 
 ## Notes and References
-  * Additional information or external sources that were used in code development
+- Additional information or external sources that were used in code development


### PR DESCRIPTION
## Minor Updates
- Added a comment explaining expected usage of pull request template
- Changed pull request template bullet points to use `-` instead of `*`, as this is the default through GitHub's web-based file editor